### PR TITLE
Add support for configurable Perplexity AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 [![smithery badge](https://smithery.ai/badge/perplexity-mcp)](https://smithery.ai/server/perplexity-mcp)
 
-A Model Context Protocol (MCP) server that provides web search functionality using [Perplexity AI's](https://www.perplexity.ai/) API.  Works with the [Anthropic](https://www.anthropic.com/news/model-context-protocol) Claude desktop client. 
+A Model Context Protocol (MCP) server that provides web search functionality using [Perplexity AI's](https://www.perplexity.ai/) API. Works with the [Anthropic](https://www.anthropic.com/news/model-context-protocol) Claude desktop client.
 
 ## Example
-Let's you use prompts like,  "Search the web to find out what's new at Anthropic in the past week."
+
+Let's you use prompts like, "Search the web to find out what's new at Anthropic in the past week."
 
 ## Glama Scores
+
 <a href="https://glama.ai/mcp/servers/ebg0za4hn9"><img width="380" height="200" src="https://glama.ai/mcp/servers/ebg0za4hn9/badge" alt="Perplexity Server MCP server" /></a>
 
 ## Components
@@ -15,6 +17,7 @@ Let's you use prompts like,  "Search the web to find out what's new at Anthropic
 ### Prompts
 
 The server provides a single prompt:
+
 - perplexity_search_web: Search the web using Perplexity AI
   - Required "query" argument for the search query
   - Optional "recency" argument to filter results by time period:
@@ -27,6 +30,7 @@ The server provides a single prompt:
 ### Tools
 
 The server implements one tool:
+
 - perplexity_search_web: Search the web using Perplexity AI
   - Takes "query" as a required string argument
   - Optional "recency" parameter to filter results (day/week/month/year)
@@ -44,10 +48,10 @@ npx -y @smithery/cli install perplexity-mcp --client claude
 
 ### Requires [UV](https://github.com/astral-sh/uv) (Fast Python package and project manager)
 
-If uv isn't installed. 
+If uv isn't installed.
 
-```bash 
-# Using Homebrew on macOS 
+```bash
+# Using Homebrew on macOS
 brew install uv
 ```
 
@@ -61,14 +65,14 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-
 Next, install the MCP server
 
 ```bash
 # Install from PyPi
 uv pip install perplexity-mcp
 ```
-or 
+
+or
 
 ```bash
 # Install from source
@@ -81,10 +85,20 @@ The following environment variable is required in your claude_desktop_config.jso
 
 - `PERPLEXITY_API_KEY`: Your Perplexity AI API key
 
+Optional environment variables:
 
+- `PERPLEXITY_MODEL`: The Perplexity model to use (defaults to "sonar" if not specified)
 
- 
+  Available models:
 
+  - `sonar-deep-research`: 128k context - Enhanced research capabilities
+  - `sonar-reasoning-pro`: 128k context - Advanced reasoning with professional focus
+  - `sonar-reasoning`: 128k context - Enhanced reasoning capabilities
+  - `sonar-pro`: 200k context - Professional grade model
+  - `sonar`: 128k context - Default model
+  - `r1-1776`: 128k context - Alternative architecture
+
+And updated list of models is avaiable (here)[https://docs.perplexity.ai/guides/model-cards]
 
 #### Claude Desktop
 
@@ -93,45 +107,48 @@ Add this tool as a mcp server by editing the Claude config file.
 On MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
+```json
+  "perplexity-mcp": {
+    "env": {
+      "PERPLEXITY_API_KEY": "XXXXXXXXXXXXXXXXXXXX",
+      "PERPLEXITY_MODEL": "sonar"
+    },
+    "command": "uv",
+    "args": [
+      "run",
+      "perplexity-mcp"
+    ]
+  }
+```
 
-  ```json
-    "perplexity-mcp": {
-      "env": {
-        "PERPLEXITY_API_KEY": "XXXXXXXXXXXXXXXXXXXX"
-      },
-      "command": "uv",
-      "args": [
-        "run",
-        "perplexity-mcp"
-      ]
-    }
-  ```
-  To verify the server is working.  Open the Claude client and use a prompt like "search the web for news about openai in the past week".  You should see an alert box open to confirm tool usage. Click "Allow for this chat".
-  
+To verify the server is working. Open the Claude client and use a prompt like "search the web for news about openai in the past week". You should see an alert box open to confirm tool usage. Click "Allow for this chat".
+
   <img width="600" alt="mcp_screenshot" src="https://github.com/user-attachments/assets/922d8f6a-8c9a-4978-8be6-788e70b4d049" />
-
-
 
 ### Cursor Installation
 
 You can also use perplexity-mcp as MCP server in Cursor.
 
-Since there no way to set an the the PERPLEXITY_API_KEY in Cursor, you'll have to create a simple wrapper script to set the environment variable.  
+Since there no way to set an the the PERPLEXITY_API_KEY in Cursor, you'll have to create a simple wrapper script to set the environment variable.
 
 Example wrapper script:
+
 ```
 #!/bin/bash
 
 # Set the your Perplexity API key
 export PERPLEXITY_API_KEY="pplx-XXXXXXXXXXXX"
 
+# Set the Perplexity model (optional, defaults to "sonar" if not set)
+export PERPLEXITY_MODEL="sonar-pro"
+
 # Run the command
 uv run perplexity-mcp
 ```
+
 Once you've completed your script, navigate to the MCP settings in Cursor and Add MCP Server. Set the server name to perplexity-mcp and the type to command. For the command, you want to specify the path of the wrapper script you just created.
 
  <img width="800" alt="mcp_screenshot" src="https://github.com/user-attachments/assets/375bf6c2-c7c7-4682-a5bb-271af62742ce" width=600>
 
-
- If everthhing is working correctly, you should now be able to call the tool from Cursor.
-  <img width="800" alt="mcp_screenshot" src="https://github.com/user-attachments/assets/d9adef45-b53c-4396-9bd4-dd798a742b48" width=600>
+If everything is working correctly, you should now be able to call the tool from Cursor.
+<img width="800" alt="mcp_screenshot" src="https://github.com/user-attachments/assets/d9adef45-b53c-4396-9bd4-dd798a742b48" width=600>

--- a/src/perplexity_mcp/server.py
+++ b/src/perplexity_mcp/server.py
@@ -112,8 +112,11 @@ async def call_perplexity(query: str, recency: str) -> str:
 
     url = "https://api.perplexity.ai/chat/completions"
 
+    # Get the model from environment variable or use "sonar" as default
+    model = os.getenv("PERPLEXITY_MODEL", "sonar")
+
     payload = {
-        "model": "sonar",
+        "model": model,
         "messages": [
             {"role": "system", "content": "Be precise and concise."},
             {"role": "user", "content": query},
@@ -173,6 +176,25 @@ def cli():
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Log which model is being used (helpful for debug)
+    model = os.getenv("PERPLEXITY_MODEL", "sonar")
+    logging.info(f"Using Perplexity AI model: {model}")
+    
+    # List available models
+    available_models = {
+        "sonar-deep-research": "128k context - Enhanced research capabilities",
+        "sonar-reasoning-pro": "128k context - Advanced reasoning with professional focus",
+        "sonar-reasoning": "128k context - Enhanced reasoning capabilities",
+        "sonar-pro": "200k context - Professional grade model",
+        "sonar": "128k context - Default model",
+        "r1-1776": "128k context - Alternative architecture"
+    }
+    
+    logging.info("Available Perplexity models (set with PERPLEXITY_MODEL environment variable):")
+    for model_name, description in available_models.items():
+        marker = "→" if model_name == model else " "
+        logging.info(f" {marker} {model_name}: {description}")
 
     asyncio.run(main())
 


### PR DESCRIPTION
# Add support for multiple Perplexity AI models 🚀

This PR adds the ability to select different Perplexity AI models via the `PERPLEXITY_MODEL` environment variable.

## Changes:
- Added support for 6 different Perplexity models (sonar, sonar-pro, sonar-reasoning, etc.)
- Updated CLI to display available models and indicate which one is active
- Enhanced README with model information and updated configuration examples
- Default model remains "sonar" if no model is specified

These changes give users more flexibility to choose the best model for their specific needs while maintaining backward compatibility. 

Let me know if you'd like any adjustments! 💫
